### PR TITLE
Adds CISO format support to lazuli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ xattr -d com.apple.quarantine lazuli
 ## Running a game
 
 Once you have a `lazuli` executable (either by building it or by grabbing one of the nightly releases),
-you can run it in the terminal with a path to the ROM you want to run (supports `.iso` and `.rvz`):
+you can run it in the terminal with a path to the ROM you want to run (supports `.iso`,`.rvz` and `.ciso/.cso`):
 
 ```sh
 lazuli --rom path/to/gamecube/game.iso
@@ -97,6 +97,15 @@ use the provided IPL ROM to boot. This will take you to the system menu, from wh
 the game.
 
 For more CLI options, `--help` is your friend.
+
+## Running on macOS
+
+If you have built lazuli yourself, you are ready to go. But if you have grabbed the zip file from 
+the nightly releases, just extract the zip file to your desired folder and remove it from quarantine:
+
+```sh
+xattr -d com.apple.quarantine lazuli
+```
 
 ## Inputs
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -14,6 +14,7 @@ use eframe::egui_wgpu::{WgpuConfiguration, WgpuSetup, WgpuSetupCreateNew};
 use eyre_pretty::eyre::Result;
 use lazuli::Lazuli;
 use lazuli::cores::Cores;
+use lazuli::disks::cso::Cso;
 use lazuli::disks::rvz::Rvz;
 use lazuli::modules::debug::{DebugModule, NopDebugModule};
 use lazuli::modules::disk::{DiskModule, NopDiskModule};
@@ -21,7 +22,7 @@ use lazuli::system::executable::Executable;
 use lazuli::system::{self, Modules};
 use modules::audio::CpalModule;
 use modules::debug::{Addr2LineModule, MapFileModule};
-use modules::disk::{IsoModule, RvzModule};
+use modules::disk::{CsoModule, IsoModule, RvzModule};
 use modules::input::GilrsModule;
 use nanorand::Rng;
 use renderer::Renderer;
@@ -54,20 +55,23 @@ impl App {
 
         let disk: Box<dyn DiskModule> = if let Some(path) = &cfg.rom {
             let extension = path.extension().and_then(|ext| ext.to_str()).unwrap();
+            let file = std::fs::File::open(path)?;
+            let reader = BufReader::new(file);
             match extension {
                 "iso" => {
-                    let file = std::fs::File::open(path)?;
-                    let reader = BufReader::new(file);
                     Box::new(IsoModule(Some(reader)))
                 }
                 "rvz" => {
-                    let file = std::fs::File::open(path)?;
-                    let reader = BufReader::new(file);
                     let rvz = Rvz::new(reader).unwrap();
                     let rvz = RvzModule::new(rvz);
                     Box::new(rvz)
                 }
-                _ => todo!(),
+                "cso" | "ciso" => {
+                    let cso = Cso::new(reader).unwrap();
+                    let cso = CsoModule::new(cso);
+                    Box::new(cso)
+                }
+                _ => unimplemented!(),
             }
         } else {
             Box::new(NopDiskModule)

--- a/crates/cubetool/src/inspect.rs
+++ b/crates/cubetool/src/inspect.rs
@@ -7,9 +7,10 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
 use disks::binrw::BinRead;
 use disks::binrw::io::BufReader;
+use disks::cso::CsoReader;
 use disks::iso::{self, Meta};
 use disks::rvz::{self, RvzReader};
-use disks::{Console, apploader, dol};
+use disks::{Console, apploader, cso, dol};
 use eyre_pretty::{Context, Result};
 
 use crate::vfs::{self, VfsEntryId, VfsGraph, VirtualEntry};
@@ -385,6 +386,64 @@ pub fn inspect_iso(input: PathBuf, filesystem: bool) -> Result<()> {
     }
 
     if let Ok(bootfile) = iso.bootfile_header() {
+        label([
+            "> Bootfile (.dol)".to_string(),
+            format!("Entry: 0x{:08X}", bootfile.entry),
+        ]);
+        dol_table(&bootfile);
+    }
+
+    Ok(())
+}
+
+pub fn inspect_cso(input: PathBuf) -> Result<()> {
+    let mut file = std::fs::File::open(&input).context("opening file")?;
+    let meta = file.metadata()?;
+    let cso = cso::Cso::new(BufReader::new(&mut file)).context("parsing .cso header")?;
+    let mut cso = CsoReader::new(cso);
+
+    label([format!(
+        "{} ({})",
+        input.file_name().unwrap().to_string_lossy(),
+        ByteSize(meta.len()).display()
+    )]);
+
+    let disk_header = cso.iso_header().context("reading ISO header from CISO")?;
+    let ciso_header = cso.inner().header();
+
+    let disk_properties = disk_properties_table(&disk_header);
+
+    let mut ciso_properties = Table::new();
+    ciso_properties
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            Cell::new("Property").set_alignment(CellAlignment::Center),
+            Cell::new("Value").set_alignment(CellAlignment::Center),
+        ]);
+
+    ciso_properties.add_row(vec![
+        Cell::new("Map Size"),
+        Cell::new(format!("{} bytes", ciso_header.map.len()))
+    ]);
+
+    ciso_properties.add_row(vec![
+        Cell::new("Block Size"),
+        Cell::new(format!("{}", ByteSize(ciso_header.block_size as u64))),
+    ]);
+
+    label(["> CISO Properties".into()]);
+    println!("{ciso_properties}");
+    label(["> Disk Properties".into()]);
+    println!("{disk_properties}");
+
+    if let Ok(apploader) = cso.apploader_header() {
+        label(["> Apploader".into()]);
+        apploader_table(&apploader);
+    }
+
+    if let Ok(bootfile) = cso.bootfile_header() {
         label([
             "> Bootfile (.dol)".to_string(),
             format!("Entry: 0x{:08X}", bootfile.entry),

--- a/crates/cubetool/src/main.rs
+++ b/crates/cubetool/src/main.rs
@@ -139,6 +139,7 @@ fn main() -> Result<()> {
             match extension {
                 "dol" => inspect::inspect_dol(input),
                 "iso" => inspect::inspect_iso(input, filesystem),
+                "ciso" | "cso" => inspect::inspect_cso(input),
                 "rvz" => inspect::inspect_rvz(input),
                 _ => bail!("unknown or missing file extension"),
             }

--- a/crates/disks/src/cso.rs
+++ b/crates/disks/src/cso.rs
@@ -3,7 +3,7 @@
 
 use std::io::{Read, Seek, SeekFrom};
 use binrw::{BinRead, BinWrite};
-use crate::{apploader, iso};
+use crate::{apploader, dol, iso};
 
 const CSO_HEADER_SIZE: usize = 0x8000; // 32KB
 const CSO_MAP_SIZE: usize = CSO_HEADER_SIZE - size_of::<u32>() - 4; // 0x8000 (32768) - 4 (magic) - 4 (block_size)
@@ -169,7 +169,7 @@ impl<R> CsoReader<R>
 where
     R: Read + Seek,
 {
-    fn iso_header(&mut self) -> Result<iso::Header, binrw::Error> {
+    pub fn iso_header(&mut self) -> Result<iso::Header, binrw::Error> {
         self.seek(SeekFrom::Start(0))?;
         iso::Header::read_be(self)
     }
@@ -182,6 +182,18 @@ where
     pub fn apploader_header(&mut self) -> Result<apploader::Header, binrw::Error> {
         self.seek(SeekFrom::Start(0x2440))?;
         apploader::Header::read(self)
+    }
+
+    pub fn bootfile(&mut self) -> Result<dol::Dol, binrw::Error> {
+        let header = self.iso_header()?;
+        self.seek(SeekFrom::Start(header.bootfile_offset as u64))?;
+        dol::Dol::read(self)
+    }
+
+    pub fn bootfile_header(&mut self) -> Result<dol::Header, binrw::Error> {
+        let header = self.iso_header()?;
+        self.seek(SeekFrom::Start(header.bootfile_offset as u64))?;
+        dol::Header::read(self)
     }
 
     pub fn filesystem(&mut self) -> Result<iso::filesystem::FileSystem, binrw::Error> {

--- a/crates/disks/src/cso.rs
+++ b/crates/disks/src/cso.rs
@@ -14,19 +14,9 @@ const CSO_MAP_SIZE: usize = CSO_HEADER_SIZE - size_of::<u32>() - 4; // 0x8000 (3
 pub struct CsoHeader {
     #[br(little)]
     /// Size of the blocks
-    block_size: u32,
+    pub block_size: u32,
     /// Used (1) or Unused (0)
-    map: [u8; CSO_MAP_SIZE]
-}
-
-impl CsoHeader {
-    pub fn block_size(&self) -> u32 {
-        self.block_size
-    }
-
-    pub fn map(&self) -> &[u8] {
-        &self.map
-    }
+    pub map: [u8; CSO_MAP_SIZE]
 }
 
 /// A Gamecube .cso file.
@@ -34,7 +24,7 @@ pub struct Cso<R> {
     /// Header of the file
     header: CsoHeader,
     /// LUT
-    cso_map: Vec<Option<u64>>,
+    map: Vec<Option<u64>>,
     /// Reader of the contents
     reader: R
 }
@@ -47,22 +37,22 @@ where
     pub fn new(mut reader: R) -> Result<Self, binrw::Error> {
         let header = CsoHeader::read(&mut reader)?;
 
-        let mut cso_map = Vec::with_capacity(CSO_MAP_SIZE);
+        let mut map= Vec::with_capacity(CSO_MAP_SIZE);
         let mut current_offset = CSO_HEADER_SIZE as u64;
 
-        for &is_present in header.map() {
+        for is_present in header.map {
             if is_present == 1
             {
-                cso_map.push(Some(current_offset));
-                current_offset += header.block_size() as u64;
+                map.push(Some(current_offset));
+                current_offset += header.block_size as u64;
             }
             else
             {
-                cso_map.push(None);
+                map.push(None);
             }
         }
 
-        Ok(Self { header, cso_map, reader })
+        Ok(Self { header, map, reader })
     }
 
     pub fn header(&self) -> &CsoHeader {
@@ -70,7 +60,7 @@ where
     }
 
     pub fn map(&self) -> &Vec<Option<u64>> {
-        &self.cso_map
+        &self.map
     }
 
     pub fn reader(&mut self) -> &mut R {
@@ -80,9 +70,9 @@ where
     /// Read from disk at the given offset and writes it into the output buffer.
     /// Returns how many bytes were actually read.
     pub fn read(&mut self, disk_offset: u64, out: &mut [u8]) -> std::io::Result<u64> {
+        let block_size = self.header().block_size as u64;
         let mut current_disk_offset = disk_offset;
         let mut remaining = out.len() as u64;
-        let block_size = self.header().block_size() as u64;
 
         while remaining > 0 {
 
@@ -93,7 +83,7 @@ where
             let out_start = (current_disk_offset - disk_offset) as usize;
             let out = &mut out[out_start as usize..][..to_read as usize];
 
-            match self.cso_map[block] {
+            match self.map[block] {
                 Some(cso_block) => {
                     self.reader.seek(SeekFrom::Start(cso_block + data_offset))?;
                     self.reader.read_exact(out)?;
@@ -165,7 +155,7 @@ where
                 self.position = self
                     .cso
                     .header()
-                    .block_size()
+                    .block_size
                     .saturating_sub_signed(x as i32) as u64;
             },
             SeekFrom::Current(x) => self.position = self.position.saturating_add_signed(x),

--- a/crates/disks/src/cso.rs
+++ b/crates/disks/src/cso.rs
@@ -1,0 +1,202 @@
+//! A `.cso` or '.ciso' file is a disc format designed
+//! to save space without the CPU overhead of actual compression
+
+use std::io::{Read, Seek, SeekFrom};
+use binrw::{BinRead, BinWrite};
+use crate::{apploader, iso};
+
+const CSO_HEADER_SIZE: usize = 0x8000; // 32KB
+const CSO_MAP_SIZE: usize = CSO_HEADER_SIZE - size_of::<u32>() - 4; // 0x8000 (32768) - 4 (magic) - 4 (block_size)
+
+/// The header of a CSO file.
+#[derive(Debug, Clone, BinRead, BinWrite)]
+#[br(big, magic = b"CISO")]
+pub struct CsoHeader {
+    #[br(little)]
+    /// Size of the blocks
+    block_size: u32,
+    /// Used (1) or Unused (0)
+    map: [u8; CSO_MAP_SIZE]
+}
+
+impl CsoHeader {
+    pub fn block_size(&self) -> u32 {
+        self.block_size
+    }
+
+    pub fn map(&self) -> &[u8] {
+        &self.map
+    }
+}
+
+/// A Gamecube .cso file.
+pub struct Cso<R> {
+    /// Header of the file
+    header: CsoHeader,
+    /// LUT
+    cso_map: Vec<Option<u64>>,
+    /// Reader of the contents
+    reader: R
+}
+
+impl<R> Cso<R>
+where
+    R: Read + Seek
+{
+    /// Creates a new [`Cso`] from the given reader.
+    pub fn new(mut reader: R) -> Result<Self, binrw::Error> {
+        let header = CsoHeader::read(&mut reader)?;
+
+        let mut cso_map = Vec::with_capacity(CSO_MAP_SIZE);
+        let mut current_offset = CSO_HEADER_SIZE as u64;
+
+        for &is_present in header.map() {
+            if is_present == 1
+            {
+                cso_map.push(Some(current_offset));
+                current_offset += header.block_size() as u64;
+            }
+            else
+            {
+                cso_map.push(None);
+            }
+        }
+
+        Ok(Self { header, cso_map, reader })
+    }
+
+    pub fn header(&self) -> &CsoHeader {
+        &self.header
+    }
+
+    pub fn map(&self) -> &Vec<Option<u64>> {
+        &self.cso_map
+    }
+
+    pub fn reader(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Read from disk at the given offset and writes it into the output buffer.
+    /// Returns how many bytes were actually read.
+    pub fn read(&mut self, disk_offset: u64, out: &mut [u8]) -> std::io::Result<u64> {
+        let mut current_disk_offset = disk_offset;
+        let mut remaining = out.len() as u64;
+        let block_size = self.header().block_size() as u64;
+
+        while remaining > 0 {
+
+            let block = (current_disk_offset / block_size) as usize;
+            let data_offset = current_disk_offset % block_size;
+            let to_read = remaining.min(block_size - data_offset);
+
+            let out_start = (current_disk_offset - disk_offset) as usize;
+            let out = &mut out[out_start as usize..][..to_read as usize];
+
+            match self.cso_map[block] {
+                Some(cso_block) => {
+                    self.reader.seek(SeekFrom::Start(cso_block + data_offset))?;
+                    self.reader.read_exact(out)?;
+                }
+                None => {
+                    out.fill(0);
+                }
+            }
+
+            current_disk_offset += to_read;
+            remaining -= to_read;
+        }
+
+        Ok(out.len() as u64 - remaining)
+    }
+}
+
+/// A wrapper around [`Cso`] providing an implementation of [`Read`] and [`Seek`].
+pub struct CsoReader<R> {
+    cso: Cso<R>,
+    position: u64,
+}
+
+impl<R> CsoReader<R> {
+    pub fn new(cso: Cso<R>) -> Self {
+        Self { cso, position: 0 }
+    }
+
+    pub fn inner(&self) -> &Cso<R> {
+        &self.cso
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Cso<R> {
+        &mut self.cso
+    }
+
+    pub fn into_inner(self) -> Cso<R> {
+        self.cso
+    }
+}
+
+impl<R> Read for CsoReader<R>
+where
+    R: Read + Seek,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = match self.cso.read(self.position, buf) {
+            Ok(read) => read,
+            Err(e) => {
+                return Err(std::io::Error::other(
+                    format!("cso disk module failed: {e}"
+                )));
+            },
+        };
+
+        self.position += read;
+        Ok(read as usize)
+    }
+}
+
+impl<R> Seek for CsoReader<R>
+where
+    R: Read + Seek,
+{
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match pos {
+            SeekFrom::Start(x) => self.position = x,
+            SeekFrom::End(x) => {
+                self.position = self
+                    .cso
+                    .header()
+                    .block_size()
+                    .saturating_sub_signed(x as i32) as u64;
+            },
+            SeekFrom::Current(x) => self.position = self.position.saturating_add_signed(x),
+        }
+
+        Ok(self.position)
+    }
+}
+
+impl<R> CsoReader<R>
+where
+    R: Read + Seek,
+{
+    fn iso_header(&mut self) -> Result<iso::Header, binrw::Error> {
+        self.seek(SeekFrom::Start(0))?;
+        iso::Header::read_be(self)
+    }
+
+    pub fn apploader(&mut self) -> Result<apploader::Apploader, binrw::Error> {
+        self.seek(SeekFrom::Start(0x2440))?;
+        apploader::Apploader::read(self)
+    }
+
+    pub fn apploader_header(&mut self) -> Result<apploader::Header, binrw::Error> {
+        self.seek(SeekFrom::Start(0x2440))?;
+        apploader::Header::read(self)
+    }
+
+    pub fn filesystem(&mut self) -> Result<iso::filesystem::FileSystem, binrw::Error> {
+        let header = self.iso_header()?;
+        self.seek(SeekFrom::Start(header.filesystem_offset as u64))?;
+        iso::filesystem::FileSystem::read(self)
+    }
+}

--- a/crates/disks/src/cso.rs
+++ b/crates/disks/src/cso.rs
@@ -2,21 +2,29 @@
 //! to save space without the CPU overhead of actual compression
 
 use std::io::{Read, Seek, SeekFrom};
-use binrw::{BinRead, BinWrite};
+use binrw::{BinRead, BinResult};
 use crate::{apploader, dol, iso};
 
 const CSO_HEADER_SIZE: usize = 0x8000; // 32KB
 const CSO_MAP_SIZE: usize = CSO_HEADER_SIZE - size_of::<u32>() - 4; // 0x8000 (32768) - 4 (magic) - 4 (block_size)
 
+#[binrw::parser(reader, endian)]
+fn parse_bool_array() -> BinResult<[bool; CSO_MAP_SIZE]> {
+    let block_used: [u8; CSO_MAP_SIZE] = BinRead::read_options(reader, endian, ())?;
+
+    Ok(block_used.map(|block| block != 0))
+}
+
 /// The header of a CSO file.
-#[derive(Debug, Clone, BinRead, BinWrite)]
+#[derive(Debug, Clone, BinRead)]
 #[br(big, magic = b"CISO")]
 pub struct CsoHeader {
     #[br(little)]
     /// Size of the blocks
     pub block_size: u32,
+    #[br(parse_with = parse_bool_array)]
     /// Used (1) or Unused (0)
-    pub map: [u8; CSO_MAP_SIZE]
+    pub map: [bool; CSO_MAP_SIZE]
 }
 
 /// A Gamecube .cso file.
@@ -41,7 +49,7 @@ where
         let mut current_offset = CSO_HEADER_SIZE as u64;
 
         for is_present in header.map {
-            if is_present == 1
+            if is_present
             {
                 map.push(Some(current_offset));
                 current_offset += header.block_size as u64;

--- a/crates/disks/src/lib.rs
+++ b/crates/disks/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod apploader;
 pub mod dol;
 pub mod iso;
+pub mod cso;
 pub mod rvz;
 
 pub use binrw;

--- a/crates/jitalloc/src/lib.rs
+++ b/crates/jitalloc/src/lib.rs
@@ -170,6 +170,11 @@ where
             }
         }
 
+        #[cfg(target_os = "macos")]
+        unsafe {
+            sys_icache_invalidate(alloc.0.as_ptr() as *mut std::ffi::c_void, data.len());
+        }
+
         alloc
     }
 }

--- a/crates/modules/src/disk.rs
+++ b/crates/modules/src/disk.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Seek, SeekFrom};
 
+use lazuli::disks::cso::{Cso, CsoReader};
 use lazuli::disks::rvz::{Rvz, RvzReader};
 use lazuli::modules::disk::DiskModule;
 
@@ -70,6 +71,42 @@ where
 }
 
 impl<R> DiskModule for RvzModule<R>
+where
+    R: Read + Seek + Send,
+{
+    fn has_disk(&self) -> bool {
+        true
+    }
+}
+
+/// An implementation of [`DiskModule`] for .cso/.ciso disks.
+pub struct CsoModule<R>(CsoReader<R>);
+
+impl<R> CsoModule<R> {
+    pub fn new(cso: Cso<R>) -> Self {
+        Self(CsoReader::new(cso))
+    }
+}
+
+impl<R> Read for CsoModule<R>
+where
+    R: Read + Seek,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<R> Seek for CsoModule<R>
+where
+    R: Read + Seek,
+{
+    fn seek(&mut self, from: SeekFrom) -> std::io::Result<u64> {
+        self.0.seek(from)
+    }
+}
+
+impl<R> DiskModule for CsoModule<R>
 where
     R: Read + Seek + Send,
 {

--- a/crates/vtxjit/src/lib.rs
+++ b/crates/vtxjit/src/lib.rs
@@ -25,6 +25,11 @@ use rustc_hash::FxHashMap;
 use crate::builder::ParserBuilder;
 use crate::parser::{Config, Meta};
 
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    unsafe fn sys_icache_invalidate(start: *mut std::ffi::c_void, len: usize);
+}
+
 #[repr(C)]
 struct UnpackedDefaultMatrices {
     pub view: u8,


### PR DESCRIPTION
Adds features requested in #29.
CISO is an other compact file format for GameCube games that reduces file size by removing empty, non-data blocks, allowing for faster loading and reduced storage usage.

Tested with the CLI tool wit (Wiimms ISO Tool v3.05a r8638 mac/arm - Dirk Clemens - 2022-08-27) to convert .iso images to .cso. 