### PR TITLE
fix ignoring uart transfer length

### DIFF
--- a/crates/dspint/zayd-tests/main.rs
+++ b/crates/dspint/zayd-tests/main.rs
@@ -108,6 +108,7 @@ fn run_test(file: file::TestFile, quiet: bool) -> Result<(), Failed> {
             sideload: None,
             ipl_lle: false,
             perform_efb_copies: false,
+            uart_escape: false,
         },
     );
 

--- a/crates/lazuli/memtest/main.rs
+++ b/crates/lazuli/memtest/main.rs
@@ -92,6 +92,7 @@ fn main() {
             sideload: None,
             ipl_lle: false,
             perform_efb_copies: false,
+            uart_escape: false,
         },
     );
 

--- a/crates/lazuli/src/system/exi.rs
+++ b/crates/lazuli/src/system/exi.rs
@@ -253,8 +253,9 @@ fn sram_transfer_write(sys: &mut System, current: u8) {
 fn uart_transfer_write(sys: &mut System) {
     assert!(!sys.external.channel0.control.dma());
     let value = sys.external.channel0.immediate;
+    let bytes = &value.to_be_bytes()[0..sys.external.channel0.control.imm_length() as usize];
 
-    for byte in value.to_be_bytes() {
+    for &byte in bytes {
         if !sys.config.uart_escape && byte == 0x1B {
             continue;
         }


### PR DESCRIPTION
The entire immediate was being written to stdout.

---

Hello, I sadly missed this because I was just zeroing out the immediate.